### PR TITLE
deploy-to-github-page

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -1,0 +1,37 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 23.7.0
+          cache: npm
+      - run: npm install
+      - run: npx next build
+        env:
+          DEPLOY_ENV: github-pages
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out
+  deploy:
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      id-token: write
+      pages: write
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,16 @@
 import type { NextConfig } from "next";
 
+const DEPLOY_ENV = process.env.DEPLOY_ENV;
+
+const githubPagesNextConfig: NextConfig = {
+  /* config options here */
+  output: "export",
+  assetPrefix: "/chelajs-website/",
+};
+
 const nextConfig: NextConfig = {
   /* config options here */
+  ...(DEPLOY_ENV === "github-pages" ? githubPagesNextConfig : {}),
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Cambios

Este pull request introduce los siguientes cambios:

1. Se agrega soporte para la implementación del proyecto Next.js en GitHub Pages. Esto se logra mediante la introducción de un nuevo objeto `githubPagesNextConfig` que establece la opción `output` en `"export"` y `assetPrefix` en `"/chelajs-website/"`. El objeto `nextConfig` principal se fusiona con `githubPagesNextConfig` si la variable de entorno `DEPLOY_ENV` se establece en `"github-pages"`.

2. Se agrega un flujo de trabajo de GitHub Actions para implementar la aplicación Next.js en GitHub Pages. Este flujo de trabajo se activa en los pushes a las ramas `main` y `deploy-to-github-page`. Realiza los siguientes pasos:
   - Verifica el código
   - Configura el entorno de Node.js
   - Instala las dependencias
   - Construye la aplicación Next.js con la variable de entorno `DEPLOY_ENV` establecida en `github-pages`
   - Carga los artefactos construidos al entorno de implementación de GitHub Pages
   - Ejecuta el paso de implementación, lo que publica la aplicación en el entorno de GitHub Pages.

Estos cambios permiten publicar el proyecto en la URL https://chelas-js.github.io/chelajs-website/