### PR TITLE
add-new-members-to-db-members-json

### DIFF
--- a/src/dbs/db-members.json
+++ b/src/dbs/db-members.json
@@ -1,0 +1,130 @@
+{
+  "members": [
+    {
+      "name": "Boris Belmar",
+      "email": "borisbelmarm@gmail.com",
+      "social_media": {
+        "linkedin": "bbelmar"
+      }
+    },
+    {
+      "name": "Catalina Araya ",
+      "email": "catalina.araya.i@usach.cl",
+      "social_media": {
+        "linkedin": null
+      }
+    },
+    {
+      "name": "Cristián Llull Torres",
+      "email": "cllullt@gmail.com",
+      "social_media": {
+        "linkedin": "https://cl.linkedin.com/in/cristian-llull-torres"
+      }
+    },
+    {
+      "name": "Daniel Nava",
+      "email": "dnavamoslercl@gmail.com",
+      "social_media": {
+        "linkedin": "https://www.linkedin.com/in/dnavamosler"
+      }
+    },
+    {
+      "name": "Grabiela ",
+      "email": "gabypealver14@gmail.com",
+      "social_media": {
+        "linkedin": "https://www.linkedin.com/in/gpeñalver"
+      }
+    },
+    {
+      "name": "Gaspar",
+      "email": "gaspardolcemascolo@gmail.com",
+      "social_media": {
+        "linkedin": null
+      }
+    },
+    {
+      "name": "Jose",
+      "email": "j.mado2210.arteaga@gmail.com",
+      "social_media": {
+        "linkedin": null
+      }
+    },
+    {
+      "name": "Jonathan Delgado",
+      "email": "jonad.correo@gmail.com",
+      "social_media": {
+        "linkedin": null
+      }
+    },
+    {
+      "name": "Jorge Castilla",
+      "email": "jorgecastillagallardo@gmail.com",
+      "social_media": {
+        "linkedin": "https://www.linkedin.com/in/jorge-castilla-dev/"
+      }
+    },
+    {
+      "name": "Juan Pablo Guerrero Bonnet",
+      "email": "jpgbonnet@gmail.com",
+      "social_media": {
+        "linkedin": "https://www.linkedin.com/in/juan-guerrero-bonnet?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app"
+      }
+    },
+    {
+      "name": "Jhen Nuñez",
+      "email": "jxelektro@gmail.com",
+      "social_media": {
+        "linkedin": "https://www.linkedin.com/in/jxelektro/"
+      }
+    },
+    {
+      "name": "Luis Orellana",
+      "email": "l.orellanagomez@gmail.com",
+      "social_media": {
+        "linkedin": null
+      }
+    },
+    {
+      "name": "Manuel Millan Caraballo",
+      "email": "mamcaraballo@gmail.com",
+      "social_media": {
+        "linkedin": "https://www.linkedin.com/in/manuelamillamc"
+      }
+    },
+    {
+      "name": "Nata",
+      "email": "natalbrnz@gmail.com",
+      "social_media": {
+        "linkedin": null
+      }
+    },
+    {
+      "name": "Oscar Plaza Guzman",
+      "email": "oscarent2@gmail.com",
+      "social_media": {
+        "linkedin": "https://www.linkedin.com/in/osplaza32/"
+      }
+    },
+    {
+      "name": "Rodrigo Llull",
+      "email": "rllullt@gmail.com",
+      "social_media": {
+        "linkedin": "https://linkedin.com/in/rodrigo-llull-torres"
+      }
+    },
+    {
+      "name": "Rodrigo Pavez",
+      "email": "ron.pavezb@gmail.com",
+      "social_media": {
+        "linkedin": "https://www.linkedin.com/in/rodrigo-ignacio-pavez-briones-291337318?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app"
+      }
+    },
+    {
+      "name": "Andrés Mármol ",
+      "email": "andresmarmolm@gmail.com",
+      "social_media": {
+        "linkedin": null
+      }
+    }
+  ]
+}

--- a/src/dbs/make-db-members.json.sh
+++ b/src/dbs/make-db-members.json.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+set -e
+
+members_json_file=$(dirname $(realpath $0))/db-members.json
+csv_file=$1
+
+if [ ! -f "$csv_file" ]; then
+  echo "Error: CSV file not found. $csv_file" 1>&2
+  exit 1
+fi
+
+cat "$members_json_file" | jq --argjson new_records "$(yq "$csv_file" -p=csv -o json)" -r '
+  .
+  | . as $doc
+  | (
+    $new_records 
+    | map(
+      {
+        name: .name,
+        email: .email,
+        social_media: {
+          linkedin: .["¿Cuál es tu perfil de LinkedIn?"]
+        }
+      }
+      | { key: .email, value: . }
+    )
+  ) as $records
+  | .members = (
+    ($records | from_entries) + (.members | map({ key: .email, value: . }) | from_entries)
+    | to_entries
+    | map(.value)
+  )
+  | .
+' > "$members_json_file"


### PR DESCRIPTION
This pull request adds new member profiles to the `db-members.json` file.

The key changes are:

- A new script `make-db-members.json.sh` has been added that generates the `db-members.json` file from a CSV file
- The script reads the existing `db-members.json` file, extracts the new records from the CSV file, and merges them with the existing members in the JSON file
- The script uses the `yq` and `jq` tools to process the CSV and JSON data
- New member profiles have been added to the `db-members.json` file

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #8 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #7 
<!-- GitButler Footer Boundary Bottom -->

