### PR TITLE
Remove extra agent instruction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENT instructions for chelajs-website
+
+Este repositorio contiene un proyecto Next.js. Para trabajar sobre él ten en cuenta lo siguiente:
+
+- La versión de Node.js utilizada se define en `.tool-versions` (23.7.0). Se recomienda usar `asdf` para gestionarla.
+- Instala dependencias con `npm install` antes de ejecutar tareas.
+- Ejecuta `npm run dev` para iniciar el entorno de desarrollo.
+- Asegura el formato y la linting de código antes de enviar cambios:
+  - `npm run fmt` formatea con Prettier.
+  - `npm run lint` comprueba la linting.
+- Todo cambio debe enviarse mediante Pull Request hacia la rama `main`. No realices commits directos en `main`.
+- Coloca documentación en la carpeta `docs`. Los archivos en español se encuentran bajo `docs/es`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,5 +8,6 @@ Este repositorio contiene un proyecto Next.js. Para trabajar sobre él ten en cu
 - Asegura el formato y la linting de código antes de enviar cambios:
   - `npm run fmt` formatea con Prettier.
   - `npm run lint` comprueba la linting.
+  - `npm run build` verifica que la aplicación compila correctamente.
 - Todo cambio debe enviarse mediante Pull Request hacia la rama `main`. No realices commits directos en `main`.
 - Coloca documentación en la carpeta `docs`. Los archivos en español se encuentran bajo `docs/es`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,4 +10,5 @@ Este repositorio contiene un proyecto Next.js. Para trabajar sobre él ten en cu
   - `npm run lint` comprueba la linting.
   - `npm run build` verifica que la aplicación compila correctamente.
 - Todo cambio debe enviarse mediante Pull Request hacia la rama `main`. No realices commits directos en `main`.
+- El commit generado con los cambios debe seguir la convención Conventional Commit.
 - Coloca documentación en la carpeta `docs`. Los archivos en español se encuentran bajo `docs/es`.


### PR DESCRIPTION
This pull request adds a new documentation file, `AGENTS.md`, to provide clear instructions for working on the `chelajs-website` project. It outlines setup steps, development practices, and conventions for contributing to the repository.

Documentation updates:

* [`AGENTS.md`](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R1-R14): Added instructions for setting up the development environment, managing dependencies, ensuring code quality (Prettier and linting), and contributing via pull requests. The file also specifies the use of Conventional Commit standards and organizes Spanish documentation under `docs/es`.


------
https://chatgpt.com/codex/tasks/task_e_68517035db5883209e61bb2927881252