### PR TITLE
Add Button component with styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "chelajs-website",
       "version": "0.1.0",
       "dependencies": {
+        "lucide-react": "^0.517.0",
         "next": "^15.3.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
@@ -6143,6 +6144,15 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.517.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.517.0.tgz",
+      "integrity": "sha512-TQCwwbwIuVG6SSutUC2Ol6PRXcuZndqoVAnDa7S7xb/RWPaiKTvLwX7byUKeh0pUgvtFh0NZZwFIDuMSeB7Iwg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/lz-string": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "lucide-react": "^0.517.0",
     "next": "^15.3.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+export type ButtonVariant = "primary" | "black-outline" | "regular" | "link";
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+}
+
+const baseClasses =
+  "font-semibold py-2 px-4 rounded transition-colors duration-200";
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary: "bg-yellow-400 hover:bg-yellow-500 text-[#343433]",
+  "black-outline":
+    "border border-black text-[#343433] hover:bg-black hover:text-white",
+  regular: "bg-gray-200 hover:bg-gray-300 text-[#343433]",
+  link: "bg-transparent text-blue-400 underline hover:no-underline p-0",
+};
+
+const Button: React.FC<ButtonProps> = ({
+  variant = "link",
+  className = "",
+  children,
+  ...rest
+}) => {
+  const classes =
+    `${baseClasses} ${variantClasses[variant]} ${className}`.trim();
+  return (
+    <button className={classes} {...rest}>
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -5,6 +5,7 @@ export type ButtonVariant = "primary" | "black-outline" | "regular" | "link";
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
+  icon?: React.ReactNode;
 }
 
 const baseClasses =
@@ -22,12 +23,14 @@ const Button: React.FC<ButtonProps> = ({
   variant = "link",
   className = "",
   children,
+  icon,
   ...rest
 }) => {
   const classes =
     `${baseClasses} ${variantClasses[variant]} ${className}`.trim();
   return (
     <button className={classes} {...rest}>
+      {icon && <span className="mr-2 inline-flex">{icon}</span>}
       {children}
     </button>
   );

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import Button from "../components/Button";
+
+const meta: Meta<typeof Button> = {
+  title: "Components/Button",
+  component: Button,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      options: ["primary", "black-outline", "regular", "link"],
+      control: { type: "select" },
+    },
+  },
+  args: {
+    children: "Button",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: { variant: "primary" },
+};
+
+export const BlackOutline: Story = {
+  args: { variant: "black-outline" },
+};
+
+export const Regular: Story = {
+  args: { variant: "regular" },
+};
+
+export const Link: Story = {
+  args: { variant: "link" },
+};

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import Button from "../components/Button";
+import { Github } from "lucide-react";
 
 const meta: Meta<typeof Button> = {
   title: "Components/Button",
@@ -13,6 +14,7 @@ const meta: Meta<typeof Button> = {
       options: ["primary", "black-outline", "regular", "link"],
       control: { type: "select" },
     },
+    icon: { control: false },
   },
   args: {
     children: "Button",
@@ -36,4 +38,8 @@ export const Regular: Story = {
 
 export const Link: Story = {
   args: { variant: "link" },
+};
+
+export const WithIcon: Story = {
+  args: { variant: "regular", icon: <Github /> },
 };


### PR DESCRIPTION
## Summary
- add `<Button>` component with primary, black outline, regular and link styles
- document button variations in Storybook

## Testing
- `npm run fmt`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685346f260048320ac9c14640b61c517