### PR TITLE
feat(buttons): use Button component

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -9,7 +9,7 @@ export interface ButtonProps
 }
 
 const baseClasses =
-  "font-semibold py-2 px-4 rounded transition-colors duration-200";
+  "font-semibold py-2 px-4 rounded transition-colors duration-200 flex items-center justify-center";
 
 const variantClasses: Record<ButtonVariant, string> = {
   primary: "bg-yellow-400 hover:bg-yellow-500 text-[#343433]",
@@ -30,7 +30,13 @@ const Button: React.FC<ButtonProps> = ({
     `${baseClasses} ${variantClasses[variant]} ${className}`.trim();
   return (
     <button className={classes} {...rest}>
-      {icon && <span className="mr-2 inline-flex">{icon}</span>}
+      {icon && (
+        <span
+          className={children ? "mr-2 flex items-center" : "flex items-center"}
+        >
+          {icon}
+        </span>
+      )}
       {children}
     </button>
   );

--- a/src/components/SessionButtons.tsx
+++ b/src/components/SessionButtons.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import Link from "next/link";
+import Button from "./Button";
+
+interface SessionButtonsProps {
+  /** Enlace para el botón 'Unete a la conversacion' */
+  joinHref?: string;
+  /** Enlace para el botón 'Cerrar sesion' */
+  logoutHref?: string;
+}
+
+const SessionButtons: React.FC<SessionButtonsProps> = ({
+  joinHref,
+  logoutHref,
+}) => {
+  return (
+    <div className="flex space-x-6">
+      {joinHref && (
+        <Link href={joinHref} className="contents">
+          <Button
+            variant="link"
+            className="border-2 border-blue-400 text-[#343433] py-1 px-6 rounded-lg hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-400 flex items-center justify-center no-underline"
+          >
+            Unete a la conversacion
+          </Button>
+        </Link>
+      )}
+      {logoutHref && (
+        <Link href={logoutHref} className="contents">
+          <Button
+            variant="primary"
+            className="py-1 px-8 rounded-lg focus:outline-none focus:ring-2 focus:ring-yellow-400 flex items-center justify-center"
+          >
+            Cerrar sesion
+          </Button>
+        </Link>
+      )}
+    </div>
+  );
+};
+
+export default SessionButtons;

--- a/src/stories/SessionButtons.stories.tsx
+++ b/src/stories/SessionButtons.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import SessionButtons from "../components/SessionButtons";
+
+const meta: Meta<typeof SessionButtons> = {
+  title: "Components/SessionButtons",
+  component: SessionButtons,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {},
+  args: {},
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Ambos: Story = {
+  args: {
+    joinHref: "#",
+    logoutHref: "#",
+  },
+};
+
+export const SoloJoin: Story = {
+  args: {
+    joinHref: "#",
+  },
+};
+
+export const SoloLogout: Story = {
+  args: {
+    logoutHref: "#",
+  },
+};
+
+export const Ninguno: Story = {
+  args: {},
+};


### PR DESCRIPTION
This pull request introduces a new `SessionButtons` component and its corresponding Storybook stories to showcase different usage scenarios. The component provides buttons for joining a conversation and logging out, with customizable links.

### New Component Addition:

* [`src/components/SessionButtons.tsx`](diffhunk://#diff-d6c0964c6fd63c71cbb1174ee02e5e3a996d1bb445084155ec37de7151f71089R1-R42): Added a new `SessionButtons` React component that renders "Unete a la conversacion" and "Cerrar sesion" buttons with customizable `joinHref` and `logoutHref` props. The buttons are styled for accessibility and responsiveness.

### Storybook Integration:

* [`src/stories/SessionButtons.stories.tsx`](diffhunk://#diff-2d5756935585e96e66bec6a9bd57a78702ce00ccacc84d94617c43d6380d7c0dR1-R39): Created Storybook stories for the `SessionButtons` component to demonstrate its behavior with various combinations of props (`joinHref` and `logoutHref`). Includes scenarios for both buttons, only one button, and no buttons.

![image](https://github.com/user-attachments/assets/ee89ddc7-9e73-4eaf-97e9-073c22727639)


------
https://chatgpt.com/codex/tasks/task_e_6853540b78988320bff60ceca9f3aa7c