### PR TITLE
feat(LandingPage): create LandingPage component

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import Button from "./Button";
+
+interface LandingPageProps {
+  buttonHref?: string;
+}
+
+const LandingPage: React.FC<LandingPageProps> = ({ buttonHref }) => {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
+      <h1 className="text-4xl font-bold text-black mb-4">Chela.js</h1>
+      <h2 className="text-xl text-blue-500 mb-8">
+        Donde la tecnología se destapa mejor con una cerveza.
+      </h2>
+      <p className="text-center text-gray-700 max-w-md mb-8">
+        En <span className="font-bold">chela.js</span>, nos reunimos cada mes en
+        algún bar de Santiago para compartir lo que más nos gusta: tecnología,
+        proyectos, ideas, problemas y descubrimientos, todo con una chela en
+        mano.
+      </p>
+      <p className="text-center text-gray-700 max-w-md mb-8">
+        Esta comunidad une a desarrolladores, diseñadores, product managers y
+        entusiastas tech para desconectarse un rato, conversar tranquilo y
+        disfrutar de buena compañía.
+      </p>
+      <p className="text-center text-gray-700 max-w-md mb-8">
+        Si trabajas en tecnología y estás en Santiago, este es tu lugar.
+      </p>
+      {buttonHref && (
+        <Button variant="primary" href={buttonHref}>
+          Unirme
+        </Button>
+      )}
+    </div>
+  );
+};
+
+export default LandingPage;

--- a/src/stories/LandingPage.stories.tsx
+++ b/src/stories/LandingPage.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import LandingPage from "../components/LandingPage";
+
+const meta = {
+  title: "Components/LandingPage",
+  component: LandingPage,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof LandingPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithHref: Story = {
+  args: {
+    buttonHref: "https://example.com",
+  },
+};


### PR DESCRIPTION
This pull request introduces a new `LandingPage` component to the project and integrates it into Storybook for documentation and testing. The most important changes include the creation of the `LandingPage` component and the addition of corresponding Storybook stories.

![image](https://github.com/user-attachments/assets/19ac7103-4fb0-4068-b9e8-0d8c6e4c693c)


### New Component Creation:
* [`src/components/LandingPage.tsx`](diffhunk://#diff-360257eeb3ff546250bd89b9fe2a68a091076257539fff441b530f6f6fbd61aeR1-R38): Added a new `LandingPage` React component, which serves as a visually appealing introduction to the `chela.js` community. It includes a title, description, and an optional button to join the community.

### Storybook Integration:
* [`src/stories/LandingPage.stories.tsx`](diffhunk://#diff-d31034a14ecf2957331a11461b23b369bd0b2f9b012b7cf64093bd96d44226c3R1-R22): Added Storybook stories for the `LandingPage` component, including a default view and a variant with a `buttonHref` prop for navigation.