### PR TITLE
feat(button): add scenario showcases

### DIFF
--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -54,22 +54,22 @@ export const BlueOutline: Story = {
 export const Showcase: Story = {
   name: "Variantes",
   decorators: [
-    (Story) => (
+    (Story, { args: { children, className, href } }) => (
       <div className="flex items-center justify-center h-screen gap-2">
-        <Button variant="primary" className="w-24">
-          button
+        <Button variant="primary" href={href} className={className}>
+          {children}
         </Button>
-        <Button variant="black-outline" className="w-24">
-          button
+        <Button variant="black-outline" href={href} className={className}>
+          {children}
         </Button>
-        <Button variant="blue-outline" className="w-24">
-          button
+        <Button variant="blue-outline" href={href} className={className}>
+          {children}
         </Button>
-        <Button variant="link" className="w-24">
-          button
+        <Button variant="link" href={href} className={className}>
+          {children}
         </Button>
-        <Button variant="regular" className="w-24">
-          button
+        <Button variant="regular" href={href} className={className}>
+          {children}
         </Button>
       </div>
     ),

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -50,3 +50,28 @@ export const BlueOutline: Story = {
     children: "Unete a la conversacion",
   },
 };
+
+export const Showcase: Story = {
+  name: "Variantes",
+  decorators: [
+    (Story) => (
+      <div className="flex items-center justify-center h-screen gap-2">
+        <Button variant="primary" className="w-24">
+          button
+        </Button>
+        <Button variant="black-outline" className="w-24">
+          button
+        </Button>
+        <Button variant="blue-outline" className="w-24">
+          button
+        </Button>
+        <Button variant="link" className="w-24">
+          button
+        </Button>
+        <Button variant="regular" className="w-24">
+          button
+        </Button>
+      </div>
+    ),
+  ],
+};


### PR DESCRIPTION
This pull request adds a new story to the `Button.stories.tsx` file to showcase various button variants. 

Key changes:

* [`src/stories/Button.stories.tsx`](diffhunk://#diff-229a47aa6ecb61b93e3a91a75c40df8c0beaadf1da96626afa50a71c30412658R53-R77): Added a new export, `Showcase`, which includes a decorator to render multiple button variants (`primary`, `black-outline`, `blue-outline`, `link`, and `regular`) in a flex layout for visual demonstration.

![image](https://github.com/user-attachments/assets/9f859aa7-8219-4d94-8a6d-9b2cdd70e852)
