### PR TITLE
feat(Hero): add Hero component and associated stories

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import Button from "./Button";
+
+interface HeroProps {
+  nextEventHref?: string;
+}
+
+const Hero: React.FC<HeroProps> = ({ nextEventHref }) => {
+  return (
+    <section className="bg-gray-100">
+      <div className="container mx-auto p-2 grid grid-cols-[1fr_2fr] gap-4">
+        <div className="py-12">
+          <h2 className="text-3xl font-bold mb-4">
+            Donde la tecnología se destapa mejor con una cerveza.
+          </h2>
+          {nextEventHref && (
+            <Button variant="primary" href={nextEventHref}>
+              Ver próximo
+            </Button>
+          )}
+        </div>
+        <div></div>
+      </div>
+    </section>
+  );
+};
+
+export default Hero;

--- a/src/stories/Hero.stories.tsx
+++ b/src/stories/Hero.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import Hero from "../components/Hero";
+
+const meta = {
+  title: "Home/Hero",
+  component: Hero,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+  argTypes: {},
+  args: {},
+} satisfies Meta<typeof Hero>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    nextEventHref: "#",
+  },
+  name: "Hero sin enlace al próximo evento",
+};
+
+export const HeroWithoutLink: Story = {
+  args: {},
+  name: "Hero con enlace al próximo evento",
+};


### PR DESCRIPTION
This pull request introduces a new `Hero` component and its corresponding Storybook stories to enhance the homepage with a dynamic section for showcasing events. The most important changes include the creation of the `Hero` component and the addition of Storybook stories for testing and documentation.

### New Component Creation:
* [`src/components/Hero.tsx`](diffhunk://#diff-1cadf8397b7345b9f320a7c7e007a8bc697f2c9deec3085de9bd17e057ac0f0aR1-R28): Added a new `Hero` component with support for an optional `nextEventHref` prop to display a button linking to the next event. The component includes a styled layout and dynamic rendering based on the prop.

### Storybook Integration:
* [`src/stories/Hero.stories.tsx`](diffhunk://#diff-ef66f7d9bc06405f06ef19085d2d4593e255b89d00f6b8413ec3c17fc18e9ed0R1-R29): Added Storybook stories for the `Hero` component, including two variations (`Default` and `HeroWithoutLink`) to test its behavior with and without the `nextEventHref` prop.

![image](https://github.com/user-attachments/assets/fbe93e86-3b80-4dd3-b224-3960be4b01d5)
