### PR TITLE
Add use case template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,12 @@ Este repositorio contiene un proyecto Next.js. Para trabajar sobre él ten en cu
 - Todo cambio debe enviarse mediante Pull Request hacia la rama `main`. No realices commits directos en `main`.
 - El commit generado con los cambios debe seguir la convención Conventional Commit.
 - Coloca documentación en la carpeta `docs`. Los archivos en español se encuentran bajo `docs/es`.
+- Los casos de uso se guardan en la carpeta `UseCase`. Para crear o modificar uno,
+  copia `UseCase/template.md` y renómbralo siguiendo el formato `UC-XX-descripcion.md`,
+  donde `XX` es el número secuencial. El título del archivo debe iniciar con el
+  mismo prefijo y número que su nombre (por ejemplo, `UC-01: Login`).
+  Completa los apartados de interlocutores, actores, procedimiento y flujo,
+  indicando **cuándo**, **dónde** y **por qué**.
 - **Los componentes deben crearse en la carpeta `src/components/`.**
 - **Todos los componentes deben ser escritos en React (TypeScript), siempre retornar un componente por defecto (export default) y utilizar las clases utilitarias de Tailwind CSS para los estilos.**
 

--- a/UseCase/template.md
+++ b/UseCase/template.md
@@ -1,0 +1,23 @@
+# UC-XX: Título del caso de uso
+
+## Interlocutores
+
+- ...
+
+## Actores
+
+- ...
+
+## Procedimiento
+
+1. ...
+
+## Flujo
+
+- ...
+
+## Contexto
+
+- **Cuándo:** ...
+- **Dónde:** ...
+- **Por qué:** ...


### PR DESCRIPTION
## Summary
- add instructions in AGENTS for sequentially enumerated use cases
- provide a template document for creating new use cases

## Testing
- `npm run lint`
- `npm run fmt`
- `npm run build` *(fails: lightningcss binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_68618a2d4ba483209219df52bf514a3c